### PR TITLE
fix: comment false does not work

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33035,7 +33035,7 @@ async function run() {
     if (!linkedIssuesCount) {
       const prId = pullRequest?.id;
       const shouldComment =
-        !linkedIssuesComments.length && core.getInput("comment") && prId;
+        !linkedIssuesComments.length && core.getBooleanInput("comment") && prId;
 
       if (shouldComment) {
         const body = core.getInput("custom-body-comment");

--- a/src/action.js
+++ b/src/action.js
@@ -76,7 +76,7 @@ async function run() {
     if (!linkedIssuesCount) {
       const prId = pullRequest?.id;
       const shouldComment =
-        !linkedIssuesComments.length && core.getInput("comment") && prId;
+        !linkedIssuesComments.length && core.getBooleanInput("comment") && prId;
 
       if (shouldComment) {
         const body = core.getInput("custom-body-comment");

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -194,7 +194,7 @@ test.each([["pull_request"], ["pull_request_target"]])(
     });
 
     // eslint-disable-next-line
-    core.getInput.mockReturnValue("true");
+    core.getBooleanInput.mockReturnValue("true");
 
     await run();
 
@@ -268,7 +268,7 @@ test.each([["pull_request"], ["pull_request_target"]])(
     });
 
     // eslint-disable-next-line
-    core.getInput.mockReturnValue("true");
+    core.getBooleanInput.mockReturnValue("true");
 
     await run();
 
@@ -318,7 +318,7 @@ test.each([["pull_request"], ["pull_request_target"]])(
     });
 
     // eslint-disable-next-line
-    core.getInput.mockReturnValue("");
+    core.getBooleanInput.mockReturnValue("");
 
     await run();
 


### PR DESCRIPTION
Fixes: #427 
Replaced `getInput` to `getBooleanInput` for reading boolean options